### PR TITLE
chore: deploy postgres, zipkin, rabbitMQ on local k8s

### DIFF
--- a/k8s/docker-kubernetes/bootstrap/postgres/configmap.yml
+++ b/k8s/docker-kubernetes/bootstrap/postgres/configmap.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+data:
+  POSTGRES_DB: isikodon
+  POSTGRES_USER: isikodon
+  POSTGRES_PASSWORD: password

--- a/k8s/docker-kubernetes/bootstrap/postgres/service.yml
+++ b/k8s/docker-kubernetes/bootstrap/postgres/service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/k8s/docker-kubernetes/bootstrap/postgres/statefulset.yml
+++ b/k8s/docker-kubernetes/bootstrap/postgres/statefulset.yml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  template:
+    metadata:
+      name: postgres
+      labels:
+        app: postgres
+    spec:
+      volumes:
+        - name: postgres
+          persistentVolumeClaim:
+            claimName: postgres-pc-volume-claim
+      containers:
+        - name: postgres
+          image: postgres
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: "/var/lib/postgresql/data"
+              name: postgres
+          envFrom:
+            - configMapRef:
+                name: postgres-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      restartPolicy: Always
+  selector:
+    matchLabels:
+      app: postgres

--- a/k8s/docker-kubernetes/bootstrap/postgres/volume.yml
+++ b/k8s/docker-kubernetes/bootstrap/postgres/volume.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-pc-volume
+  labels:
+    type: local
+    app: postgres
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /mnt/data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pc-volume-claim
+  labels:
+    app: postgres
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/docker-kubernetes/bootstrap/rabbitmq/configmap.yml
+++ b/k8s/docker-kubernetes/bootstrap/rabbitmq/configmap.yml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-config
+data:
+  enabled_plugins: |
+    [rabbitmq_management,rabbitmq_peer_discovery_k8s].
+
+  rabbitmq.conf: |
+    ## Cluster formation. See https://www.rabbitmq.com/cluster-formation.html to learn more.
+    cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
+    cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+    ## Should RabbitMQ node name be computed from the pod's hostname or IP address?
+    ## IP addresses are not stable, so using [stable] hostnames is recommended when possible.
+    ## Set to "hostname" to use pod hostnames.
+    ## When this value is changed, so should the variable used to set the RABBITMQ_NODENAME
+    ## environment variable.
+    cluster_formation.k8s.address_type = hostname
+    ## How often should node cleanup checks run?
+    cluster_formation.node_cleanup.interval = 30
+    ## Set to false if automatic removal of unknown/absent nodes
+    ## is desired. This can be dangerous, see
+    ##  * https://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup
+    ##  * https://groups.google.com/forum/#!msg/rabbitmq-users/wuOfzEywHXo/k8z_HWIkBgAJ
+    cluster_formation.node_cleanup.only_log_warning = true
+    cluster_partition_handling = autoheal
+    ## See https://www.rabbitmq.com/ha.html#master-migration-data-locality
+    queue_master_locator=min-masters
+    ## This is just an example.
+    ## This enables remote access for the default user with well known credentials.
+    ## Consider deleting the default user and creating a separate user with a set of generated
+    ## credentials instead.
+    ## Learn more at https://www.rabbitmq.com/access-control.html#loopback-users
+    loopback_users.guest = false

--- a/k8s/docker-kubernetes/bootstrap/rabbitmq/rbac.yml
+++ b/k8s/docker-kubernetes/bootstrap/rabbitmq/rbac.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rabbitmq
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rabbitmq-peer-discovery-rbac
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rabbitmq-peer-discovery-rbac
+subjects:
+  - kind: ServiceAccount
+    name: rabbitmq
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rabbitmq-peer-discovery-rbac

--- a/k8s/docker-kubernetes/bootstrap/rabbitmq/service.yml
+++ b/k8s/docker-kubernetes/bootstrap/rabbitmq/service.yml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+    type: LoadBalancer
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      protocol: TCP
+      port: 15672
+      targetPort: 15672
+      nodePort: 31672
+    - name: amqp
+      protocol: TCP
+      port: 5672
+      targetPort: 5672
+      nodePort: 30672
+  selector:
+    app: rabbitmq

--- a/k8s/docker-kubernetes/bootstrap/rabbitmq/statefulset.yml
+++ b/k8s/docker-kubernetes/bootstrap/rabbitmq/statefulset.yml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+# See the Prerequisites section of https://www.rabbitmq.com/cluster-formation.html#peer-discovery-k8s.
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+spec:
+  serviceName: rabbitmq
+  # Three nodes is the recommended minimum. Some features may require a majority of nodes
+  # to be available.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      serviceAccountName: rabbitmq
+      terminationGracePeriodSeconds: 10
+      nodeSelector:
+        # Use Linux nodes in a mixed OS kubernetes cluster.
+        # Learn more at https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-os
+        kubernetes.io/os: linux
+      containers:
+        - name: rabbitmq-k8s
+          image: rabbitmq:3.8
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/rabbitmq
+          # Learn more about what ports various protocols use
+          # at https://www.rabbitmq.com/networking.html#ports
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 15672
+            - name: amqp
+              protocol: TCP
+              containerPort: 5672
+          livenessProbe:
+            exec:
+              # This is just an example. There is no "one true health check" but rather
+              # several rabbitmq-diagnostics commands that can be combined to form increasingly comprehensive
+              # and intrusive health checks.
+              # Learn more at https://www.rabbitmq.com/monitoring.html#health-checks.
+              #
+              # Stage 2 check:
+              command: ["rabbitmq-diagnostics", "status"]
+            initialDelaySeconds: 60
+            # See https://www.rabbitmq.com/monitoring.html for monitoring frequency recommendations.
+            periodSeconds: 60
+            timeoutSeconds: 15
+          readinessProbe:
+            exec:
+              # This is just an example. There is no "one true health check" but rather
+              # several rabbitmq-diagnostics commands that can be combined to form increasingly comprehensive
+              # and intrusive health checks.
+              # Learn more at https://www.rabbitmq.com/monitoring.html#health-checks.
+              #
+              # Stage 1 check:
+              command: ["rabbitmq-diagnostics", "ping"]
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+          imagePullPolicy: Always
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RABBITMQ_USE_LONGNAME
+              value: "true"
+            # See a note on cluster_formation.k8s.address_type in the config file section
+            - name: K8S_SERVICE_NAME
+              value: rabbitmq
+            - name: RABBITMQ_NODENAME
+              value: rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local
+            - name: K8S_HOSTNAME_SUFFIX
+              value: .$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local
+            - name: RABBITMQ_ERLANG_COOKIE
+              value: "mycookie"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: rabbitmq-config
+            items:
+              - key: rabbitmq.conf
+                path: rabbitmq.conf
+              - key: enabled_plugins
+                path: enabled_plugins

--- a/k8s/docker-kubernetes/bootstrap/zipkin/service.yml
+++ b/k8s/docker-kubernetes/bootstrap/zipkin/service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+spec:
+  selector:
+    app: zipkin
+  ports:
+    - name: zipkin-primary-port
+      port: 9411
+      targetPort: 9411
+
+  type: ClusterIP

--- a/k8s/docker-kubernetes/bootstrap/zipkin/statefulset.yml
+++ b/k8s/docker-kubernetes/bootstrap/zipkin/statefulset.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zipkin
+  labels:
+    app: zipkin
+spec:
+  serviceName: zipkin
+  replicas: 1
+  template:
+    metadata:
+      name: zipkin
+      labels:
+        app: zipkin
+    spec:
+      containers:
+        - name: zipkin
+          image: openzipkin/zipkin
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      restartPolicy: Always
+  selector:
+    matchLabels:
+      app: zipkin


### PR DESCRIPTION
- create manifests for postgres
	- Service - PersistentVolume & PersistentVolumeClaim - StatefulSet - ConfigMap
- create manifests for zipkin
	- service - StatefulSet
- copy manifests for rabbitmq from amigoscode [repo](https://github.com/amigoscode/microservices/tree/main/k8s/minikube/bootstrap/rabbitmq)
    - rabbitmq isn't usually deployed this way and so it isn't as important to keep tabs of all these changes - this is for learning purposes only